### PR TITLE
Ideas

### DIFF
--- a/sig.cabal
+++ b/sig.cabal
@@ -17,6 +17,7 @@ library
                      , Sig.Examples
                      , Sig.Main
   build-depends:       base >=4.9 && < 5
+                     , async
                      , binary
                      , bytestring
                      , parallel


### PR DESCRIPTION
I think it's easier to explain by showing the code.

I did small benchmarks with `kleene`:
- `run`: this is what already existed.
- `runIO`, I noticed that we `runSerial` marshalls statematchine per "thread", so I rearranged stuff (and used `async` to not lie about `IO`.
- `runIOC`, another optimisation was to remove re-serialisation of `StateMachine` per run, which for small inputs has noticeable overhead.

This is just an ideas, maybe something to adopt.
```
benchmarking match/dfaP
time                 3.274 ms   (2.966 ms .. 3.560 ms)
                     0.967 R²   (0.956 R² .. 0.988 R²)
mean                 3.050 ms   (2.983 ms .. 3.177 ms)
std dev              274.6 μs   (188.2 μs .. 379.9 μs)
variance introduced by outliers: 60% (severely inflated)

benchmarking match/dfaPIO
time                 1.627 ms   (1.525 ms .. 1.788 ms)
                     0.918 R²   (0.851 R² .. 0.986 R²)
mean                 1.984 ms   (1.784 ms .. 2.670 ms)
std dev              1.111 ms   (384.3 μs .. 2.239 ms)
variance introduced by outliers: 98% (severely inflated)

benchmarking match/dfaPIO'
time                 670.2 μs   (644.4 μs .. 695.1 μs)
                     0.986 R²   (0.980 R² .. 0.991 R²)
mean                 668.1 μs   (647.6 μs .. 695.0 μs)
std dev              79.61 μs   (64.02 μs .. 114.7 μs)
variance introduced by outliers: 81% (severely inflated)
```

*I use 2MB input for the benchmarks*